### PR TITLE
Fix error in authentication hook

### DIFF
--- a/apps/storefront/src/hooks/useAuthentication.tsx
+++ b/apps/storefront/src/hooks/useAuthentication.tsx
@@ -10,12 +10,14 @@ export function useAuthenticated() {
       try {
          if (typeof window !== 'undefined' && window.localStorage) {
             const cookies = document.cookie.split(';')
-            const loggedInCookie =
-               cookies
-                  .find((cookie) => cookie.startsWith('logged-in'))
-                  .split('=')[1] === 'true'
+            const cookieString = cookies.find((cookie) =>
+               cookie.trim().startsWith('logged-in')
+            )
+            const loggedInCookie = cookieString
+               ? cookieString.split('=')[1] === 'true'
+               : false
 
-            setAuthenticated(loggedInCookie ?? false)
+            setAuthenticated(loggedInCookie)
          }
       } catch (error) {
          console.error({ error })


### PR DESCRIPTION
## Summary
- handle missing cookie in useAuthenticated hook to avoid runtime error

## Testing
- `bun run lint` *(fails: Invalid Options)*

------
https://chatgpt.com/codex/tasks/task_e_684f1aa566fc832a99a5573299700952